### PR TITLE
Prevent false positive for `has`

### DIFF
--- a/src/SimpleCache.php
+++ b/src/SimpleCache.php
@@ -39,7 +39,7 @@ class SimpleCache implements PsrSimpleCacheInterface {
 	 * @inheritDoc
 	 */
 	public function has( $key ): bool {
-		return boolval( $this->get( $key ) );
+		return $this->get( $key, false ) !== false;
 	}
 
 	/**


### PR DESCRIPTION
As per your docblock of `get` and as usually correct, 0 (zero) could be considered a valid value and the cache contains that value.
Other values even if valid (see https://3v4l.org/SVmjH) could create unexpected behaviors because `has` would return `false`. 

Consider the case of the empty array, the value exists in the cache, it's just empty but exists. 

Therefore I would explictly set one unique value to check against when you want to know if a value exists or not in the cache.

I see you use `false` because of the underline implementation, even if `false` could be considered a valid value and I would use `null` in place of that I can understand your reasons due to WordPress function.