### PR TITLE
Return a stored value if exists in internal data

### DIFF
--- a/src/SimpleCache.php
+++ b/src/SimpleCache.php
@@ -50,11 +50,17 @@ class SimpleCache implements PsrSimpleCacheInterface {
 	 */
 	public function get( $key, $default = null ) {
 		$this->assertKeyIsValid( $key );
+		
+		if($this->data[$key] ?? false) {
+			return $this->data[$key];
+		}
 
 		$value = get_transient( $key );
 		if ( false === $value ) {
 			return $default;
 		}
+		
+		$this->data[$key] = $value;
 
 		return $value;
 	}

--- a/src/SimpleCache.php
+++ b/src/SimpleCache.php
@@ -51,7 +51,7 @@ class SimpleCache implements PsrSimpleCacheInterface {
 	public function get( $key, $default = null ) {
 		$this->assertKeyIsValid( $key );
 		
-		if($this->data[$key] ?? false) {
+		if ( $this->data[$key] ?? false ) {
 			return $this->data[$key];
 		}
 


### PR DESCRIPTION
The idea as far as I see is to return a value from the internal data storage instead of retrieving it from the transient storage.

At least this is what I could understand by reading the `getMultiple` and `set` methods, but apparently the `get` does not have this "shortcircuit" kind of.

I don't know about the implementation, just suggesting because of coherency otherwise which is the purpose of `$data`?

The problem with this approach is that the value as transient will not be retrieved anymore after the first time, which could be an improvements in terms of resources, you may perhaps retrieve a fresh value everytime you call `get`.

If it that the reason, I would suggest to remove the internal storage from the other methods and rely only on the transient.

Btw, if this PR is accepted the #2 does no longer make sense.